### PR TITLE
Roll back the develocity plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 spotless-gradle = "7.0.2"
 blowdryer-gradle = "1.7.1"
-develocity = "3.18"
+develocity = "3.18.2"
 jfrog-gradle = "5.2.5"
 rule-api = "2.9.0.4061"
 gradle-plugin-shadow = "8.3.5"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 spotless-gradle = "7.0.2"
 blowdryer-gradle = "1.7.1"
-develocity = "3.19.1"
+develocity = "3.18"
 jfrog-gradle = "5.2.5"
 rule-api = "2.9.0.4061"
 gradle-plugin-shadow = "8.3.5"


### PR DESCRIPTION
Version 3.18 is the highest compatible with our current Develocity installation