### PR TITLE
Configure Renovate to keep Develocity below 3.19

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,6 +25,13 @@
       ],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"
+    },
+    {
+      "matchPackageNames": [
+        "com.gradle.develocity",
+        "com.gradle.develocity:com.gradle.develocity.gradle.plugin"
+      ],
+      "allowedVersions": "<3.19"
     }
   ],
   "reviewers": ["team:security-cloud-squad"]


### PR DESCRIPTION
See https://docs.gradle.com/develocity/compatibility/#develocity_compatibility
Our instance is on 2024.2 at the moment