### PR TITLE
Update exclusion patterns in `cleanupOldVersion` task

### DIFF
--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.sonar-plugin.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.sonar-plugin.gradle.kts
@@ -32,7 +32,7 @@ val cleanupTask = tasks.register<Delete>("cleanupOldVersion") {
     delete(
         fileTree(layout.buildDirectory.dir("libs")).matching {
             include("$projectName-*.jar")
-            exclude("$projectName-$projectVersion-*.jar")
+            exclude("$projectName-$projectVersion.jar", "$projectName-$projectVersion-*.jar")
         }
     )
 }


### PR DESCRIPTION
In some cases (sonar-text) the cleanup task removed the regular jar (i.e. w/o any modifiers) before execution of tests, and tests are loading this jar on the execution classpath.