### PR TITLE
SONARGO-680 Add input for "goLangCiLint" task to trigger task re-run

### DIFF
--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.go-binary-builder.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.go-binary-builder.gradle.kts
@@ -86,8 +86,8 @@ if (isCi()) {
         commandLine(
             "golangci-lint",
             "run",
-            "--go=${inputs.properties["goVersion"]}",
-            "--out-format=checkstyle:${reportPath.get().asFile}"
+            "--output.checkstyle.path",
+            "${reportPath.get().asFile}"
         )
         // golangci-lint returns non-zero exit code if there are issues, we don't want to fail the build in this case.
         // A report with issues will be later ingested by SonarQube.


### PR DESCRIPTION
There are changes in golangci-lint:
https://golangci-lint.run/docs/product/migration-guide/

Removed: --go string
The --out-format replaced by other flags, --output.checkstyle.path in our case