### PR TITLE
Don't limit the number of issues detected by golangci-lint

### DIFF
--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.go-binary-builder.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.go-binary-builder.gradle.kts
@@ -86,6 +86,10 @@ if (isCi()) {
         commandLine(
             "golangci-lint",
             "run",
+            // Don't limit the number of issues in the report
+            "--max-issues-per-linter=0",
+            "--max-same-issues=0",
+            // Output format for SonarQube ingestion
             "--output.checkstyle.path",
             "${reportPath.get().asFile}"
         )


### PR DESCRIPTION
```
--max-issues-per-linter int         Maximum issues count per one linter. Set to 0 to disable (default 50)
--max-same-issues int               Maximum count of issues with the same text. Set to 0 to disable (default 3)
```
We should feed all the issues into SQ