### PR TITLE
CLOUDSEC-11 Add base plugin to exclude BouncyCastle from build classpath

### DIFF
--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.artifactory-configuration.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.artifactory-configuration.gradle.kts
@@ -17,6 +17,7 @@
 import org.sonarsource.cloudnative.gradle.ArtifactoryConfiguration
 
 plugins {
+    id("org.sonarsource.cloud-native.base")
     // `maven-publish` is required for the `artifactory` plugin (or the root project shoudn't be published)
     `maven-publish`
     id("com.jfrog.artifactory")

--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.base.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.base.gradle.kts
@@ -1,0 +1,24 @@
+/*
+ * SonarSource Cloud Native Gradle Modules
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+plugins {}
+
+configurations.matching { it.name == "kotlinBouncyCastleConfiguration" }.configureEach {
+    // Workaround for https://github.com/gradle/gradle/issues/35309.
+    // When any of cloud-native Gradle plugins is applied in a project
+    // whose Gradle version embeds Kotlin <2.3.20, there will be an unnecessary dependency on build classpath.
+    withDependencies { clear() }
+}

--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.code-style-conventions.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.code-style-conventions.gradle.kts
@@ -18,6 +18,7 @@ import com.diffplug.blowdryer.Blowdryer
 import org.sonarsource.cloudnative.gradle.CodeStyleConvention
 
 plugins {
+    id("org.sonarsource.cloud-native.base")
     id("com.diffplug.spotless")
 }
 

--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.dart-license-file-generator.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.dart-license-file-generator.gradle.kts
@@ -25,6 +25,10 @@ import org.sonarsource.cloudnative.gradle.DartLicenseGenerationConfig
 import org.sonarsource.cloudnative.gradle.areDirectoriesEqual
 import org.sonarsource.cloudnative.gradle.copyDirectory
 
+plugins {
+    id("org.sonarsource.cloud-native.base")
+}
+
 /**
  * This plugin collects license files from third-party Dart runtime dependencies and places them
  * into a resources folder. It provides:

--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.go-binary-builder.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.go-binary-builder.gradle.kts
@@ -30,6 +30,7 @@ import org.sonarsource.cloudnative.gradle.goVersion
 import org.sonarsource.cloudnative.gradle.isCi
 
 plugins {
+    id("org.sonarsource.cloud-native.base")
     id("org.sonarsource.cloud-native.go-docker-environment")
 }
 

--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.go-docker-environment.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.go-docker-environment.gradle.kts
@@ -25,6 +25,10 @@ import org.sonarsource.cloudnative.gradle.goLangCiLintVersion
 import org.sonarsource.cloudnative.gradle.goVersion
 import org.sonarsource.cloudnative.gradle.isCi
 
+plugins {
+    id("org.sonarsource.cloud-native.base")
+}
+
 val dockerExecutable = findExecutable("docker")
 
 val goBuildExtension = extensions.findByType<GoBuild>() ?: extensions.create<GoBuild>("goBuild")

--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.go-license-file-generator.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.go-license-file-generator.gradle.kts
@@ -25,6 +25,10 @@ import org.sonarsource.cloudnative.gradle.GoLicenseGenerationConfig
 import org.sonarsource.cloudnative.gradle.areDirectoriesEqual
 import org.sonarsource.cloudnative.gradle.copyDirectory
 
+plugins {
+    id("org.sonarsource.cloud-native.base")
+}
+
 /**
  * This plugin is used for generating license files for third-party GO runtime-dependencies into the resources folder.
  * It provides a validation task to ensure that the license files in the resource folder are up-to-date.

--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.integration-test.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.integration-test.gradle.kts
@@ -24,6 +24,7 @@ import org.sonarsource.cloudnative.gradle.IntegrationTestExtension
 // Inspiration: https://docs.gradle.org/current/samples/sample_jvm_multi_project_with_additional_test_types.html
 
 plugins {
+    id("org.sonarsource.cloud-native.base")
     java
     id("org.sonarsource.cloud-native.java-conventions")
 }

--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.java-conventions.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.java-conventions.gradle.kts
@@ -19,6 +19,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED
 import org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED
 
 plugins {
+    id("org.sonarsource.cloud-native.base")
     `java-library`
     jacoco
 }

--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.license-file-generator.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.license-file-generator.gradle.kts
@@ -24,6 +24,7 @@ import org.sonarsource.cloudnative.gradle.areFilesEqual
 import org.sonarsource.cloudnative.gradle.copyDirectory
 
 plugins {
+    id("org.sonarsource.cloud-native.base")
     id("com.github.jk1.dependency-license-report")
 }
 

--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.publishing-configuration.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.publishing-configuration.gradle.kts
@@ -20,6 +20,7 @@ import org.sonarsource.cloudnative.gradle.PublishingConfiguration
 import org.sonarsource.cloudnative.gradle.signingCondition
 
 plugins {
+    id("org.sonarsource.cloud-native.base")
     signing
     `maven-publish`
     // Connection to artifactory is configured from the root project; applying it here enables publishing of this project

--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.rule-api.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.rule-api.gradle.kts
@@ -20,6 +20,10 @@ import org.sonarsource.cloudnative.gradle.registerRuleApiGenerateTask
 import org.sonarsource.cloudnative.gradle.registerRuleApiUpdateTask
 import org.sonarsource.cloudnative.gradle.repox
 
+plugins {
+    id("org.sonarsource.cloud-native.base")
+}
+
 val ruleApi: Configuration = configurations.create("ruleApi")
 val ruleApiExtension = extensions.create<RuleApiExtension>("ruleApi")
 

--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.sonar-plugin.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.sonar-plugin.gradle.kts
@@ -15,6 +15,7 @@
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 plugins {
+    id("org.sonarsource.cloud-native.base")
     id("org.sonarsource.cloud-native.java-conventions")
     id("org.sonarsource.cloud-native.code-style-conventions")
     id("org.sonarsource.cloud-native.publishing-configuration")

--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.swift-license-file-generator.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.swift-license-file-generator.gradle.kts
@@ -24,6 +24,10 @@ import org.sonarsource.cloudnative.gradle.SwiftLicenseGenerationConfig
 import org.sonarsource.cloudnative.gradle.areDirectoriesEqual
 import org.sonarsource.cloudnative.gradle.copyDirectory
 
+plugins {
+    id("org.sonarsource.cloud-native.base")
+}
+
 /**
  * This plugin collects license files from third-party Swift runtime dependencies and places them
  * into a resources folder. It provides:


### PR DESCRIPTION
Workaround for a Gradle issue: when a
cloud-native Gradle plugin is applied in a project whose Gradle version
embeds Kotlin <2.3.20, an unnecessary BouncyCastle dependency appears on
the build classpath. The new `base` plugin clears it, and all other
plugins now apply it.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>