### PR TITLE
CLOUDSEC-30 ci: migrate GitHub-hosted Ubuntu runners to warp-custom-ubuntu-24-04

### DIFF
--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestCreated_job:
     name: Pull Request Created
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
     # For external PR, ticket should be created manually

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       actions: write
     steps:

--- a/.github/workflows/shadow-scan.yml
+++ b/.github/workflows/shadow-scan.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: Build
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'shadow_scan')
     steps:


### PR DESCRIPTION
## Summary

- Replace `github-ubuntu-latest-*` labels with `warp-custom-ubuntu-24-04` in GitHub Actions workflows, per platform guidance (WarpBuild general-purpose Ubuntu runner).

## Files

- `.github/workflows/build.yml`
- `.github/workflows/pr-cleanup.yml`
- `.github/workflows/PullRequestCreated.yml`
- `.github/workflows/shadow-scan.yml`