### PR TITLE
BUILD-10835 Migrate GitHub-hosted Ubuntu runners to warp-custom-ubuntu-24-04

### DIFF
--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestCreated_job:
     name: Pull Request Created
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
     # For external PR, ticket should be created manually

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       actions: write
     steps:

--- a/.github/workflows/shadow-scan.yml
+++ b/.github/workflows/shadow-scan.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: Build
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'shadow_scan')
     steps:


### PR DESCRIPTION
BUILD-10835 This change moves CI from GitHub-hosted Ubuntu runner labels to the shared WarpBuild image `warp-custom-ubuntu-24-04`, in line with the platform runner migration.

## Summary

- Updates all workflows in this repository that used `github-ubuntu-latest-*` so jobs run on `warp-custom-ubuntu-24-04` instead.

## Files touched

- `.github/workflows/build.yml`
- `.github/workflows/pr-cleanup.yml`
- `.github/workflows/PullRequestCreated.yml`
- `.github/workflows/shadow-scan.yml`

## Notes for reviewers

- No change to job logic, permissions, or steps beyond `runs-on`.
- Please confirm workflows still match org expectations for this repo after merge.