### PR TITLE
CLOUDSEC-39 Update, force and sort library versions to avoid dependency risks

### DIFF
--- a/gradle-modules/build.gradle.kts
+++ b/gradle-modules/build.gradle.kts
@@ -34,6 +34,15 @@ dependencies {
     implementation(libs.license.report)
 }
 
+configurations.all {
+    resolutionStrategy {
+        // Pinned to avoid dependency risks
+        force(libs.log4j.core)
+        force(libs.plexus.utils)
+    }
+}
+
+
 configurations.matching { it.name == "kotlinBouncyCastleConfiguration" }.configureEach {
     // Workaround for https://github.com/gradle/gradle/issues/35309.
     // When any of cloud-native Gradle plugins is applied in a project

--- a/gradle-modules/build.gradle.kts
+++ b/gradle-modules/build.gradle.kts
@@ -42,7 +42,6 @@ configurations.all {
     }
 }
 
-
 configurations.matching { it.name == "kotlinBouncyCastleConfiguration" }.configureEach {
     // Workaround for https://github.com/gradle/gradle/issues/35309.
     // When any of cloud-native Gradle plugins is applied in a project

--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.base.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.base.gradle.kts
@@ -16,6 +16,14 @@
  */
 plugins {}
 
+configurations.all {
+    resolutionStrategy {
+        // Pinned to avoid dependency risks
+        force("org.apache.logging.log4j:log4j-core:2.26.0")
+        force("org.codehaus.plexus:plexus-utils:4.0.3")
+    }
+}
+
 configurations.matching { it.name == "kotlinBouncyCastleConfiguration" }.configureEach {
     // Workaround for https://github.com/gradle/gradle/issues/35309.
     // When any of cloud-native Gradle plugins is applied in a project

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,23 +1,25 @@
 [versions]
-spotless-gradle = "8.4.0"
 blowdryer-gradle = "1.7.1"
-develocity = "4.0.3"
-jackson = "2.21.3"
+develocity = "4.4.2"
+gradle-license-report = "3.1.4"
+gradle-plugin-shadow = "9.4.2"
+jackson = "2.22.0"
 jfrog-gradle = "6.0.4"
-gradle-plugin-shadow = "9.4.1"
-gradle-license-report = "3.1.2"
-sonar-scanner-gradle = "7.3.0.8198"
+sonar-scanner-gradle = "7.3.1.8318"
+spotless-gradle = "8.6.0"
 
 [libraries]
-diffplug-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless-gradle" }
-diffplug-blowdryer-setup = { module = "com.diffplug.blowdryerSetup:com.diffplug.blowdryerSetup.gradle.plugin", version.ref = "blowdryer-gradle" }
 develocity = { module = "com.gradle.develocity:com.gradle.develocity.gradle.plugin", version.ref = "develocity" }
-jfrog-buildinfo-gradle = { module = "org.jfrog.buildinfo:build-info-extractor-gradle", version.ref = "jfrog-gradle" }
-shadow = { module = "com.gradleup.shadow:com.gradleup.shadow.gradle.plugin", version.ref = "gradle-plugin-shadow" }
+diffplug-blowdryer-setup = { module = "com.diffplug.blowdryerSetup:com.diffplug.blowdryerSetup.gradle.plugin", version.ref = "blowdryer-gradle" }
+diffplug-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless-gradle" }
 jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson" }
+jfrog-buildinfo-gradle = { module = "org.jfrog.buildinfo:build-info-extractor-gradle", version.ref = "jfrog-gradle" }
 license-report = { module = "com.github.jk1:gradle-license-report", version.ref = "gradle-license-report" }
+shadow = { module = "com.gradleup.shadow:com.gradleup.shadow.gradle.plugin", version.ref = "gradle-plugin-shadow" }
 
 [plugins]
-spotless = { id = "com.diffplug.spotless", version.ref = "spotless-gradle" }
+com.diffplug.blowdryerSetup = "com.diffplug.blowdryerSetup:1.7.1"
+com.gradleup.shadow = "com.gradleup.shadow:9.4.2"
 develocity = { id = "com.gradle.develocity", version.ref = "develocity" }
 sonarqube = { id = "org.sonarqube", version.ref = "sonar-scanner-gradle" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless-gradle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,8 +18,6 @@ license-report = { module = "com.github.jk1:gradle-license-report", version.ref 
 shadow = { module = "com.gradleup.shadow:com.gradleup.shadow.gradle.plugin", version.ref = "gradle-plugin-shadow" }
 
 [plugins]
-com.diffplug.blowdryerSetup = "com.diffplug.blowdryerSetup:1.7.1"
-com.gradleup.shadow = "com.gradleup.shadow:9.4.2"
 develocity = { id = "com.gradle.develocity", version.ref = "develocity" }
 sonarqube = { id = "org.sonarqube", version.ref = "sonar-scanner-gradle" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless-gradle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,8 @@ gradle-license-report = "3.1.4"
 gradle-plugin-shadow = "9.4.2"
 jackson = "2.22.0"
 jfrog-gradle = "6.0.4"
+log4j = "2.26.0"
+plexus-utils = "4.0.3"
 sonar-scanner-gradle = "7.3.1.8318"
 spotless-gradle = "8.6.0"
 
@@ -15,6 +17,8 @@ diffplug-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", v
 jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson" }
 jfrog-buildinfo-gradle = { module = "org.jfrog.buildinfo:build-info-extractor-gradle", version.ref = "jfrog-gradle" }
 license-report = { module = "com.github.jk1:gradle-license-report", version.ref = "gradle-license-report" }
+log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
+plexus-utils = { module = "org.codehaus.plexus:plexus-utils", version.ref = "plexus-utils" }
 shadow = { module = "com.gradleup.shadow:com.gradleup.shadow.gradle.plugin", version.ref = "gradle-plugin-shadow" }
 
 [plugins]


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependency updates:**
  - Updated `develocity`, `jackson`, `sonar-scanner-gradle`, and `spotless-gradle` versions.
  - Bumped `gradle-license-report` and `gradle-plugin-shadow` to newer versions.
- **Dependency management:**
  - Reorganized `libs.versions.toml` to maintain alphabetical ordering for better maintainability.
  - Added missing plugin declarations for `com.diffplug.blowdryerSetup` and `com.gradleup.shadow`.
- **Security hardening:**
  - Added `log4j-core` and `plexus-utils` dependencies.
  - Forced version resolution for `log4j-core` and `plexus-utils` in `build.gradle.kts` to mitigate risks.

<sub>This will update automatically on new commits.</sub>