### PR TITLE
CLOUDSEC-44 Upgrade Jackson 2.22.0 → 3.2.0

### DIFF
--- a/gradle-modules/src/main/kotlin/org/sonarsource/cloudnative/gradle/AnalyzerLicensingPackagingRenderer.kt
+++ b/gradle-modules/src/main/kotlin/org/sonarsource/cloudnative/gradle/AnalyzerLicensingPackagingRenderer.kt
@@ -63,6 +63,8 @@ class AnalyzerLicensingPackagingRenderer(
     private val defaultDependencyLicenseOverrides = mapOf(
         "com.fasterxml.jackson.dataformat:jackson-dataformat-smile" to APACHE_LICENSE_FILE_NAME,
         "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml" to APACHE_LICENSE_FILE_NAME,
+        "tools.jackson.dataformat:jackson-dataformat-smile" to APACHE_LICENSE_FILE_NAME,
+        "tools.jackson.dataformat:jackson-dataformat-yaml" to APACHE_LICENSE_FILE_NAME,
         "com.fasterxml.woodstox:woodstox-core" to APACHE_LICENSE_FILE_NAME,
         "com.salesforce:apex-jorje-lsp-minimized" to "BSD-3.txt",
         "org.codehaus.woodstox:stax2-api" to "BSD-2.txt"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ blowdryer-gradle = "1.7.1"
 develocity = "4.4.2"
 gradle-license-report = "3.1.4"
 gradle-plugin-shadow = "9.4.2"
-jackson = "2.22.0"
+jackson = "3.2.0"
 jfrog-gradle = "6.0.4"
 log4j = "2.26.0"
 plexus-utils = "4.0.3"
@@ -14,7 +14,7 @@ spotless-gradle = "8.6.0"
 develocity = { module = "com.gradle.develocity:com.gradle.develocity.gradle.plugin", version.ref = "develocity" }
 diffplug-blowdryer-setup = { module = "com.diffplug.blowdryerSetup:com.diffplug.blowdryerSetup.gradle.plugin", version.ref = "blowdryer-gradle" }
 diffplug-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless-gradle" }
-jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson" }
+jackson-bom = { module = "tools.jackson:jackson-bom", version.ref = "jackson" }
 jfrog-buildinfo-gradle = { module = "org.jfrog.buildinfo:build-info-extractor-gradle", version.ref = "jfrog-gradle" }
 license-report = { module = "com.github.jk1:gradle-license-report", version.ref = "gradle-license-report" }
 log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }


### PR DESCRIPTION
## Summary

- Bumps Jackson BOM from `2.22.0` to `3.2.0`
- Updates BOM group ID from `com.fasterxml.jackson:jackson-bom` to `tools.jackson:jackson-bom` (Jackson 3.x moved to a new Maven group)
- Adds `tools.jackson.dataformat` license override entries alongside the existing `com.fasterxml.jackson.dataformat` ones for backward compatibility

## Test plan

- [ ] Gradle resolves the new BOM without conflicts
- [ ] Build passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)