### PR TITLE
SONARIAC-3032 plugin version for sonariac

### DIFF
--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.project-version-provisioning.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.project-version-provisioning.gradle.kts
@@ -1,0 +1,23 @@
+/*
+ * SonarSource Cloud Native Gradle Modules
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+plugins {}
+
+tasks.named<ProcessResources>("processResources") {
+    filesMatching("**/pluginVersion.properties") {
+        expand(mapOf("version" to project.version))
+    }
+}


### PR DESCRIPTION
Related to the following ticket: [https://sonarsource.atlassian.net/browse/SONARIAC-3032](url)

----
## Summary by Gitar

- **Gradle configuration:**
  - Added `org.sonarsource.cloud-native.project-version-provisioning.gradle.kts` to automate version substitution.
  - Configured `processResources` task to inject `project.version` into `pluginVersion.properties` files.

<sub>This will update automatically on new commits.</sub>