### PR TITLE
CLOUDSEC-52 Edit for project verion provisioning to be more robust during build in the CI

### DIFF
--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.project-version-provisioning.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.project-version-provisioning.gradle.kts
@@ -17,7 +17,8 @@
 plugins {}
 
 tasks.named<ProcessResources>("processResources") {
+    val version = project.version.toString()
     filesMatching("**/pluginVersion.properties") {
-        expand(mapOf("version" to project.version))
+        expand(mapOf("version" to version))
     }
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **Build process improvements:**
  - Capture `project.version` into a local variable before expansion to ensure consistent property resolution during `processResources`.

<sub>This will update automatically on new commits.</sub>