### PR TITLE
SONARIAC-2308 Migrate codebase from JSR305 to JSpecify

### DIFF
--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.code-style-conventions.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.code-style-conventions.gradle.kts
@@ -60,7 +60,9 @@ spotless {
     }
     format("javaMisc") {
         target("src/**/package-info.java")
-        licenseHeaderFile(licenseHeaderFile, "@javax.annotation")
+        // SONARIAC-2308 - when all our repositories will migrate to JSpecify then it can be re-enabled.
+        // In the meantime the repositories should configure licenseHeaderFile
+//        licenseHeaderFile(licenseHeaderFile, "@javax.annotation")
     }
 }
 

--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.code-style-conventions.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.code-style-conventions.gradle.kts
@@ -60,9 +60,7 @@ spotless {
     }
     format("javaMisc") {
         target("src/**/package-info.java")
-        // SONARIAC-2308 - when all our repositories will migrate to JSpecify then it can be re-enabled.
-        // In the meantime the repositories should configure licenseHeaderFile
-//        licenseHeaderFile(licenseHeaderFile, "@javax.annotation")
+        licenseHeaderFile(licenseHeaderFile, "")
     }
 }
 

--- a/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.code-style-conventions.gradle.kts
+++ b/gradle-modules/src/main/kotlin/org.sonarsource.cloud-native.code-style-conventions.gradle.kts
@@ -60,7 +60,7 @@ spotless {
     }
     format("javaMisc") {
         target("src/**/package-info.java")
-        licenseHeaderFile(licenseHeaderFile, "")
+        licenseHeaderFile(licenseHeaderFile, "(@javax.annotation|@org.jspecify)")
     }
 }
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Code style conventions:**
    - Disabled `licenseHeaderFile` in `code-style-conventions.gradle.kts` for `package-info.java` as part of the JSpecify migration

<sub>This will update automatically on new commits.</sub>